### PR TITLE
Multithreading

### DIFF
--- a/maven_repo_util.py
+++ b/maven_repo_util.py
@@ -14,6 +14,10 @@ from subprocess import PIPE
 from xml.etree.ElementTree import ElementTree
 
 
+# Constants
+MAX_THREADS = 10
+
+# Functions
 def setLogLevel(level):
     """Sets the desired log level."""
     lLevel = level.lower()


### PR DESCRIPTION
I added paralelization in two places where creation of multiple requests slows down the builder considerably:
1. _listArtifacts
2. _filterExcludedRepositories

There are 10 threads in a pool, so there can be only 10 concurrent request at a time.
