### PR TITLE
Fix #82: Improve error handling in lftp execution

### DIFF
--- a/artifact_list_builder.py
+++ b/artifact_list_builder.py
@@ -724,7 +724,7 @@ class ArtifactListBuilder:
     def _lftpFind(self, url):
         if maven_repo_util.urlExists(url):
             lftp = Popen(r'lftp -c "set ssl:verify-certificate no ; open ' + url
-                         + ' ; find  ."', stdout=PIPE, shell=True)
+                         + ' || exit 1; find  ."', stdout=PIPE, shell=True)
             result = lftp.communicate()[0]
             if lftp.returncode:
                 raise IOError("lftp find in %s ended by return code %d" % (url, lftp.returncode))


### PR DESCRIPTION
If lftp is not able to change to the appropriate directory, it should immediately exit.