### PR TITLE
Fix #82: Improve error handling in lftp execution

### DIFF
--- a/artifact_list_builder.py
+++ b/artifact_list_builder.py
@@ -724,7 +724,7 @@ class ArtifactListBuilder:
     def _lftpFind(self, url):
         if maven_repo_util.urlExists(url):
             lftp = Popen(r'lftp -c "set ssl:verify-certificate no ; open ' + url
-                         + ' || exit 1; find  ."', stdout=PIPE, shell=True)
+                         + ' && find . || exit 1"', stdout=PIPE, shell=True)
             result = lftp.communicate()[0]
             if lftp.returncode:
                 raise IOError("lftp find in %s ended by return code %d" % (url, lftp.returncode))


### PR DESCRIPTION
List the content of the appropriate directory only if lftp is able to change to the directory. Otherwise exit with return code 1.