### PR TITLE
Fix interaction with AProx 0.25.x and above

### DIFF
--- a/aprox_apis.py
+++ b/aprox_apis.py
@@ -296,9 +296,11 @@ class AproxApi(UrlRequester):
             request["injectedBOMs"] = injectedBOMs
         data = json.dumps(request)
 
+        headers = {"Content-Type": "application/json"}
+
         logging.debug("Requesting urlmap with config '%s'", data)
 
-        response = self._postUrl(url, data=data)
+        response = self._postUrl(url, data=data, headers=headers)
 
         if response.status == 200:
             responseContent = response.read()
@@ -472,9 +474,11 @@ class AproxApi(UrlRequester):
             request["injectedBOMs"] = injectedBOMs
         data = json.dumps(request)
 
+        headers = {"Content-Type": "application/json"}
+
         logging.debug("Requesting paths with config '%s'", data)
 
-        response = self._postUrl(url, data=data)
+        response = self._postUrl(url, data=data, headers=headers)
 
         if response.status == 200:
             responseContent = response.read()


### PR DESCRIPTION
When using the mentioned version there was no response nor a failure in log. I
found out that aprox did not identify the target of the request because of
Content-Type header missing.