### PR TITLE
Fix crash when no extra value is set

### DIFF
--- a/reporter.py
+++ b/reporter.py
@@ -87,7 +87,7 @@ def generate_artifact_page(ma, roots, paths, repo_url, output, groupids, optiona
         li = "<li>"
         is_inherited_or_mixin = False
         for rel in path:
-            if "inherited" in rel.extra or "mixin" in rel.extra:
+            if rel.extra and ("inherited" in rel.extra or "mixin" in rel.extra):
                 is_inherited_or_mixin = True
                 break
             dec = rel.declaring


### PR DESCRIPTION
2016-05-02 09:30:12,360 WARNING (MainThread): Target report path maven-repository-report exists. Deleting...
Traceback (most recent call last):
  File "./artifact_list_generator.py", line 188, in <module>
    main()
  File "./artifact_list_generator.py", line 71, in main
    artifactList = _generateArtifactList(options, args)
  File "./artifact_list_generator.py", line 139, in _generateArtifactList
    reporter.generate_report(options.reportdir, config, artifactList, options.reportname)
  File "/mnt/hudson_workspace/workspace/fuse-team-mead-6.2-fuse-integration-repo-builder/reporter.py", line 54, in generate_report
    generate_artifact_page(ma, roots, art_spec.paths, art_spec.url, output, groupids, optional_artifacts)
  File "/mnt/hudson_workspace/workspace/fuse-team-mead-6.2-fuse-integration-repo-builder/reporter.py", line 90, in generate_artifact_page
    if "inherited" in rel.extra or "mixin" in rel.extra:
TypeError: argument of type 'NoneType' is not iterable
