### PR TITLE
Head request should consider 302 as successful result too

### DIFF
--- a/maven_repo_util.py
+++ b/maven_repo_util.py
@@ -395,7 +395,7 @@ def urlExists(url):
             connection = httplib.HTTPSConnection(parsedUrl[1])
         connection.request('HEAD', parsedUrl[2], headers={"User-Agent": "Python-Maven Repository Builder"})
         response = connection.getresponse()
-        return response.status == 200
+        return response.status in [200, 302]
     else:
         if protocol == 'file':
             url = url[7:]


### PR DESCRIPTION
The check in maven_repo_util#urlExists considers only 200 as success,
but status 302 Found is ?newly? used by
http://download.eng.bos.redhat.com/brewroot/repos/<tag>/latest/maven/<path>
when the path exists.